### PR TITLE
Bug Fix for trailing equals characters in query string params

### DIFF
--- a/examples/helpers.js
+++ b/examples/helpers.js
@@ -14,7 +14,7 @@ function readUrlParams() {
     .slice(1, window.location.search.length)
     .split('&')
     .reduce((result, value) => {
-      const param = value.split('=');
+      const param = value.split(/=(.+)/, 2);
 
       return {
         ...result,


### PR DESCRIPTION
Base64 encoding uses equals characters to pad as needed at end of encoded strings. This change fixes a bug in helpers that was not allowing for equals characters within the values of query string params.