### PR TITLE
[SDK-1284] Update web sdk version

### DIFF
--- a/examples/custom-interactions/index.html
+++ b/examples/custom-interactions/index.html
@@ -10,15 +10,15 @@
 
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.css"
+      href="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.esm.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer.js"
     ></script>
   </head>
   <body>

--- a/examples/helpers.js
+++ b/examples/helpers.js
@@ -18,7 +18,7 @@ function readUrlParams() {
 
       return {
         ...result,
-        [param[0].replace('-', '')]: param[1],
+        [param[0].replace('-', '').toLowerCase()]: param[1],
       };
     }, {});
 }

--- a/examples/loading-models/index.html
+++ b/examples/loading-models/index.html
@@ -10,15 +10,15 @@
 
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.css"
+      href="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.esm.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer.js"
     ></script>
   </head>
   <body>

--- a/examples/loading-models/main.js
+++ b/examples/loading-models/main.js
@@ -1,11 +1,14 @@
+import { readDefaultStreamKey } from '../helpers.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   main();
 });
 
 async function main() {
   const viewer = document.querySelector('vertex-viewer');
+  const streamKey = readDefaultStreamKey();
 
-  loadModelByStreamKey(viewer, 'your-stream-key');
+  loadModelByStreamKey(viewer, streamKey);
 }
 
 /**

--- a/examples/picking/index.html
+++ b/examples/picking/index.html
@@ -10,15 +10,15 @@
 
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.css"
+      href="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.esm.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer.js"
     ></script>
   </head>
   <body>

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -1,5 +1,5 @@
 import { loadDefaultStreamKey } from '../helpers.js';
-import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/index.esm.js';
+import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/index.esm.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   main();

--- a/examples/work-instructions/index.html
+++ b/examples/work-instructions/index.html
@@ -10,15 +10,15 @@
 
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.css"
+      href="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/viewer.esm.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@latest/dist/viewer.js"
+      src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer.js"
     ></script>
   </head>
   <body>

--- a/examples/work-instructions/instructions.js
+++ b/examples/work-instructions/instructions.js
@@ -1,4 +1,4 @@
-import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/viewer/index.esm.js';
+import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/index.esm.js';
 import { readDefaultStreamKey } from '../helpers.js';
 import steps from './steps.js';
 


### PR DESCRIPTION
Update examples to use x-range version instead of `latest` to prevent future breaking changes from causing issues.

Additionally, this change updates the "load model" example to use the stream key query parameter if passed, as referenced in https://vertexvis.atlassian.net/browse/SDK-1017.