### PR TITLE
[SDK-1025] Updating examples to wait for the vertex-viewer to be defined as a custom element in the window

### DIFF
--- a/examples/custom-interactions/main.js
+++ b/examples/custom-interactions/main.js
@@ -1,4 +1,5 @@
 import { loadDefaultStreamKey } from '../helpers.js';
+import { defineCustomElements } from '@vertexvis/viewer/loader';
 
 class CustomInteractionHandler {
   constructor() {
@@ -114,12 +115,13 @@ class CustomInteractionHandler {
   }
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-  await window.customElements.whenDefined('vertex-viewer');
+document.addEventListener('DOMContentLoaded', () => {
+  defineCustomElements(window).then(() => main());
   main();
 });
 
 async function main() {
+  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   await loadDefaultStreamKey(viewer);
 

--- a/examples/custom-interactions/main.js
+++ b/examples/custom-interactions/main.js
@@ -1,5 +1,5 @@
 import { loadDefaultStreamKey } from '../helpers.js';
-import { defineCustomElements } from '@vertexvis/viewer/loader';
+import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
 
 class CustomInteractionHandler {
   constructor() {
@@ -117,11 +117,9 @@ class CustomInteractionHandler {
 
 document.addEventListener('DOMContentLoaded', () => {
   defineCustomElements(window).then(() => main());
-  main();
 });
 
 async function main() {
-  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   await loadDefaultStreamKey(viewer);
 

--- a/examples/custom-interactions/main.js
+++ b/examples/custom-interactions/main.js
@@ -114,7 +114,8 @@ class CustomInteractionHandler {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  await window.customElements.whenDefined('vertex-viewer');
   main();
 });
 

--- a/examples/loading-models/main.js
+++ b/examples/loading-models/main.js
@@ -1,11 +1,11 @@
 import { readDefaultStreamKey } from '../helpers.js';
 
-document.addEventListener('DOMContentLoaded', async () => {
-  await window.customElements.whenDefined('vertex-viewer');
+document.addEventListener('DOMContentLoaded', () => {
   main();
 });
 
 async function main() {
+  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   const streamKey = readDefaultStreamKey();
 

--- a/examples/loading-models/main.js
+++ b/examples/loading-models/main.js
@@ -1,11 +1,11 @@
 import { readDefaultStreamKey } from '../helpers.js';
+import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
 
 document.addEventListener('DOMContentLoaded', () => {
-  main();
+  defineCustomElements(window).then(() => main());
 });
 
 async function main() {
-  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   const streamKey = readDefaultStreamKey();
 

--- a/examples/loading-models/main.js
+++ b/examples/loading-models/main.js
@@ -1,6 +1,7 @@
 import { readDefaultStreamKey } from '../helpers.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  await window.customElements.whenDefined('vertex-viewer');
   main();
 });
 

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -1,12 +1,12 @@
 import { loadDefaultStreamKey } from '../helpers.js';
 import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/index.mjs';
 
-document.addEventListener('DOMContentLoaded', async () => {
-  await window.customElements.whenDefined('vertex-viewer');
+document.addEventListener('DOMContentLoaded', () => {
   main();
 });
 
 async function main() {
+  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   await loadDefaultStreamKey(viewer);
 

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -1,7 +1,8 @@
 import { loadDefaultStreamKey } from '../helpers.js';
 import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/index.mjs';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  await window.customElements.whenDefined('vertex-viewer');
   main();
 });
 

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -1,12 +1,12 @@
 import { loadDefaultStreamKey } from '../helpers.js';
 import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/index.mjs';
+import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
 
 document.addEventListener('DOMContentLoaded', () => {
-  main();
+  defineCustomElements(window).then(() => main());
 });
 
 async function main() {
-  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   await loadDefaultStreamKey(viewer);
 

--- a/examples/work-instructions/main.js
+++ b/examples/work-instructions/main.js
@@ -4,13 +4,13 @@ import {
   applyWorkInstruction,
   initializeWorkInstructions,
 } from './instructions.js';
+import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@latest/dist/esm/loader.mjs';
 
 document.addEventListener('DOMContentLoaded', () => {
-  main();
+  defineCustomElements(window).then(() => main());
 });
 
 async function main() {
-  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   await loadDefaultStreamKey(viewer);
   await initializeWorkInstructions(viewer);

--- a/examples/work-instructions/main.js
+++ b/examples/work-instructions/main.js
@@ -5,12 +5,12 @@ import {
   initializeWorkInstructions,
 } from './instructions.js';
 
-document.addEventListener('DOMContentLoaded', async () => {
-  await window.customElements.whenDefined('vertex-viewer');
+document.addEventListener('DOMContentLoaded', () => {
   main();
 });
 
 async function main() {
+  await window.customElements.whenDefined('vertex-viewer');
   const viewer = document.querySelector('vertex-viewer');
   await loadDefaultStreamKey(viewer);
   await initializeWorkInstructions(viewer);

--- a/examples/work-instructions/main.js
+++ b/examples/work-instructions/main.js
@@ -5,7 +5,8 @@ import {
   initializeWorkInstructions,
 } from './instructions.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  await window.customElements.whenDefined('vertex-viewer');
   main();
 });
 


### PR DESCRIPTION
## What

<!-- Explain the implementation and architectural changes you're introducing with this PR. -->
In some browsers the custom elements are not yet defined. We will want to wait for those prior to trying to access any custom elements on our web component. 

## Ticket

<!-- Link to ticket for this feature or fix. -->
https://vertexvis.atlassian.net/browse/SDK-1025

## Test Plan

<!-- Describe how your changes should be tested. -->
Ensure the regression steps on SDK-1025 do not happen any more with this change. Note, you'll need to update the html in the ticket with the code referenced in the example to get this to work. 

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->
N/A

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->
N/a

## Dependencies

<!-- Link to other PRs or tickets. -->
N/A
